### PR TITLE
Resolve Swagger validation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,5 @@ For running local tests you will need to run the following:
 docker-compose up -d
 ./scripts/heimdall_tunnel.sh <path/to/access/pem>
 ```
+
+Copyright 2017 Mastodon C

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0-alpha17"]
+  :dependencies [[org.clojure/clojure "1.9.0-beta2"]
                  [com.cognitect/transit-clj "0.8.290"]
                  [com.stuartsierra/component "0.3.1"]
                  [com.taoensso/timbre "4.7.4"]
@@ -14,8 +14,8 @@
                  [aero "1.1.2"]
                  [com.gfredericks/schpec "0.1.2"]
                  [spootnik/signal "0.2.1"]
-                 [metosin/compojure-api "2.0.0-alpha7"]
-                 [metosin/spec-tools "0.3.2"]
+                 [metosin/spec-tools "0.5.0"]
+                 [metosin/compojure-api "2.0.0-alpha9" :exclusions [metosin/spec-tools]]
                  [kixi/kixi.spec "0.1.7"]
                  [kixi/kixi.comms "0.2.21"]
                  [kixi/kixi.log "0.1.4"]

--- a/src/witan/httpapi/api.clj
+++ b/src/witan/httpapi/api.clj
@@ -63,13 +63,13 @@
 (def not-found-routes
   (let [not-found-resp (not-found "Not Found")]
     (context "/" []
-             (GET "*" [] not-found-resp)
-             (HEAD "*" [] not-found-resp)
-             (PATCH "*" [] not-found-resp)
-             (DELETE "*" [] not-found-resp)
-             (OPTIONS "*" [] not-found-resp)
-             (POST "*" [] not-found-resp)
-             (PUT "*" [] not-found-resp))))
+             (GET "/*" [] not-found-resp)
+             (HEAD "/*" [] not-found-resp)
+             (PATCH "/*" [] not-found-resp)
+             (DELETE "/*" [] not-found-resp)
+             (OPTIONS "/*" [] not-found-resp)
+             (POST "/*" [] not-found-resp)
+             (PUT "/*" [] not-found-resp))))
 
 (def auth-routes
   (context "/api" []

--- a/src/witan/httpapi/api.clj
+++ b/src/witan/httpapi/api.clj
@@ -1,6 +1,6 @@
 (ns witan.httpapi.api
-  (:require [compojure.api.sweet :refer [context GET POST ANY PUT resource api]]
-            [ring.util.http-response :refer [ok unauthorized]]
+  (:require [compojure.api.sweet :refer :all]
+            [ring.util.http-response :refer [ok unauthorized not-found]]
             [clj-time.core              :as t]
             [taoensso.timbre :as log]
             ;;
@@ -59,6 +59,17 @@
   (context "/" []
     (GET "/healthcheck" []
       (str "hello"))))
+
+(def not-found-routes
+  (let [not-found-resp (not-found "Not Found")]
+    (context "/" []
+             (GET "*" [] not-found-resp)
+             (HEAD "*" [] not-found-resp)
+             (PATCH "*" [] not-found-resp)
+             (DELETE "*" [] not-found-resp)
+             (OPTIONS "*" [] not-found-resp)
+             (POST "*" [] not-found-resp)
+             (PUT "*" [] not-found-resp))))
 
 (def auth-routes
   (context "/api" []
@@ -259,4 +270,5 @@
             :tags [{:name "api", :description "API routes for Witan"}]}}}
    healthcheck-routes
    auth-routes
-   api-routes))
+   api-routes
+   not-found-routes))

--- a/src/witan/httpapi/api.clj
+++ b/src/witan/httpapi/api.clj
@@ -55,12 +55,6 @@
   (and (>= status OK)
        (< status BAD_REQUEST)))
 
-(def not-found
-  (context "/" []
-    (ANY "/*" []
-      {:status NOT_FOUND
-       :body "Not Found"})))
-
 (def healthcheck-routes
   (context "/" []
     (GET "/healthcheck" []
@@ -265,5 +259,4 @@
             :tags [{:name "api", :description "API routes for Witan"}]}}}
    healthcheck-routes
    auth-routes
-   api-routes
-   not-found))
+   api-routes))

--- a/src/witan/httpapi/spec.clj
+++ b/src/witan/httpapi/spec.clj
@@ -129,7 +129,8 @@
 (s/def ::paging (s/keys :req-un [::total ::count ::index]))
 (s/def ::paged-items (s/keys :req-un [::items ::paging]))
 
-(s/def ::files (s/coll-of ::file-info))
+#_(s/def ::files (s/coll-of ::file-info))
+(s/def ::files (s/coll-of (s/keys)))
 (s/def ::paged-metadata-items (s/keys :req-un [::files ::paging]))
 
 ;; Receipts

--- a/src/witan/httpapi/spec.clj
+++ b/src/witan/httpapi/spec.clj
@@ -129,8 +129,7 @@
 (s/def ::paging (s/keys :req-un [::total ::count ::index]))
 (s/def ::paged-items (s/keys :req-un [::items ::paging]))
 
-#_(s/def ::files (s/coll-of ::file-info))
-(s/def ::files (s/coll-of (s/keys)))
+(s/def ::files (s/coll-of ::file-info))
 (s/def ::paged-metadata-items (s/keys :req-un [::files ::paging]))
 
 ;; Receipts

--- a/test/witan/httpapi/api_test.clj
+++ b/test/witan/httpapi/api_test.clj
@@ -102,6 +102,11 @@
     (when-success r
       (is (= "hello" (-> r :body slurp))))))
 
+(deftest noexist-404-test
+  (let [r @(http/get (url "/no-exist")
+                     {:throw-exceptions false})]
+    (is (= 404 (:status r)) (prn r))))
+
 ;; Currently doesn't pass and there doesn't appear to be a
 ;; nice way to achieve this
 #_(deftest nomethod-405-test
@@ -133,8 +138,8 @@
         r @(http/get (url "/api/files")
                      (with-default-opts
                        {:headers {:authorization (:auth-token auth)}}))]
-    (when-success r)
-    (is-spec :witan.httpapi.spec/paged-metadata-items (:body r))))
+    (when-success r
+      (is-spec :witan.httpapi.spec/paged-metadata-items (:body r)))))
 
 (deftest get-files-paging-test
   (let [auth (get-auth-tokens)

--- a/test/witan/httpapi/api_test.clj
+++ b/test/witan/httpapi/api_test.clj
@@ -102,11 +102,6 @@
     (when-success r
       (is (= "hello" (-> r :body slurp))))))
 
-(deftest noexist-404-test
-  (let [r @(http/get (url "/notexist")
-                     {:throw-exceptions false})]
-    (is (= 404 (:status r)))))
-
 ;; Currently doesn't pass and there doesn't appear to be a
 ;; nice way to achieve this
 #_(deftest nomethod-405-test

--- a/test/witan/httpapi/spec_test.clj
+++ b/test/witan/httpapi/spec_test.clj
@@ -1,0 +1,19 @@
+(ns witan.httpapi.spec-test
+  (:require [witan.httpapi.spec :as s]
+            [clojure.test :refer :all]
+            [spec-tools.swagger.core :as swagger]))
+
+(deftest no-empty-requireds
+  "This proves our specs aren't doing anything weird"
+  (testing "file-info"
+    (let [schema (swagger/transform ::s/file-info)
+          results (atom [])]
+      (clojure.walk/postwalk #(do (when (= [] (:required %))
+                                    (swap! results conj %)) %) schema)
+      (is (empty? @results))))
+  (testing "paged-metadata-items"
+    (let [schema (swagger/transform ::s/paged-metadata-items)
+          results (atom [])]
+      (clojure.walk/postwalk #(do (when (= [] (:required %))
+                                    (swap! results conj %)) %) schema)
+      (is (empty? @results)))))


### PR DESCRIPTION
Turned out there were two things upsetting Swagger validation:

* A catch-all route `/*` which was added to return 404s. Since removed
  the application will return 204s instead. C'est la vie. I'm fine
  with this for now.

* Empty `:required` keys in object definitions. I submit a PR to
  metosin/spec-tools and this was merged into `0.5.0` which we're now using.
