### PR TITLE
Fix the response code as a reason

### DIFF
--- a/src/witan/httpapi/components/activities.clj
+++ b/src/witan/httpapi/components/activities.clj
@@ -195,7 +195,7 @@
        database id
        (if (= REDIRECT status)
          (create-download-link! database user id file-id (get headers "location"))
-         (create-error! database id file-id status))))
+         (create-error! database id file-id (code->reason status)))))
     (return-receipt id)))
 
 (defn- retreive-download-link

--- a/src/witan/httpapi/response_codes.clj
+++ b/src/witan/httpapi/response_codes.clj
@@ -8,3 +8,15 @@
 (def BAD_REQUEST 400)
 (def UNAUTHORISED 401)
 (def NOT_FOUND 404)
+
+(defn code->reason
+  [c]
+  (case c
+    OK           "OK"
+    CREATED      "Created"
+    ACCEPTED     "Accepted"
+    REDIRECT     "Redirected"
+    SEE_OTHER    "See Other"
+    BAD_REQUEST  "Bad Request"
+    UNAUTHORISED "Unauthorised"
+    NOT_FOUND    "Not Found"))


### PR DESCRIPTION
This caused an error where `status` was mapped to `reason` in the error structure