### PR TITLE
Add Datapack endpoints for creating and retrieving datapacks

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
                  [spootnik/signal "0.2.1"]
                  [metosin/spec-tools "0.5.0"]
                  [metosin/compojure-api "2.0.0-alpha10" :exclusions [metosin/spec-tools]]
-                 [kixi/kixi.spec "0.1.27" :upgrade :kixi]
+                 [kixi/kixi.spec "0.1.28" :upgrade :kixi]
                  [kixi/kixi.comms "0.2.37" :upgrade :kixi]
                  [kixi/kixi.log "0.1.6" :upgrade :kixi]
                  [kixi/kixi.metrics "0.4.1" :exclusions [org.slf4j/slf4j-api] :upgrade :kixi]

--- a/src/witan/httpapi/api.clj
+++ b/src/witan/httpapi/api.clj
@@ -110,9 +110,9 @@
           (fail s r))))
 
     (GET "/groups" req
-         :summary "Return a list of groups."
-         :query-params [{count :- ::s/count nil}
-                        {index :- ::s/index nil}]
+      :summary "Return a list of groups."
+      :query-params [{count :- ::s/count nil}
+                     {index :- ::s/index nil}]
       :return ::s/paged-group-items
       (let [[s r] (query/get-groups (requester req) (user req) {:count count :index index})]
         (if (success? s)
@@ -125,7 +125,7 @@
         :summary "Return a list of files the user has access to"
         :query-params [{count :- ::s/count nil}
                        {index :- ::s/index nil}]
-        :return ::s/paged-metadata-items
+        :return ::s/paged-files
         (let [[s r] (query/get-files-by-user (requester req) (user req) {:count count :index index})]
           (if (success? s)
             (success s r)
@@ -135,8 +135,8 @@
         :summary "Creates an upload address for a new file"
         :return ::s/receipt-id-container
         (let [[s r headers] (activities/create-file-upload!
-                              (activities req)
-                              (user req))]
+                             (activities req)
+                             (user req))]
           (if (success? s)
             (success ACCEPTED r headers)
             (fail s))))
@@ -149,10 +149,10 @@
                         upload-id :- ::s/id]
           :return ::s/upload-link-response
           (let [[s r headers] (activities/get-upload-link-response
-                                (activities req)
-                                (user req)
-                                id
-                                upload-id)]
+                               (activities req)
+                               (user req)
+                               id
+                               upload-id)]
             (if (success? s)
               (success s r headers)
               (fail s))))
@@ -172,10 +172,10 @@
           :body [metadata ::s/file-metadata-put]
           :return ::s/receipt-id-container
           (let [[s r headers] (activities/create-metadata!
-                                (activities req)
-                                (user req)
-                                metadata
-                                id)]
+                               (activities req)
+                               (user req)
+                               metadata
+                               id)]
             (if (success? s)
               (success ACCEPTED r headers)
               (fail s r))))
@@ -186,10 +186,10 @@
           :body [metadata-updates ::s/file-metadata-post]
           :return ::s/receipt-id-container
           (let [[s r headers] (activities/update-metadata!
-                                (activities req)
-                                (user req)
-                                metadata-updates
-                                id)]
+                               (activities req)
+                               (user req)
+                               metadata-updates
+                               id)]
             (if (success? s)
               (success ACCEPTED r headers)
               (fail s))))
@@ -200,10 +200,10 @@
                         error-id :- ::s/id]
           :return ::s/error-container
           (let [[s r] (activities/get-error-response
-                        (activities req)
-                        (user req)
-                        error-id
-                        id)]
+                       (activities req)
+                       (user req)
+                       error-id
+                       id)]
             (if (success? s)
               (success s r)
               (fail s))))
@@ -211,7 +211,7 @@
         (GET "/sharing" req
           :summary "Return sharing data for a specific file"
           :path-params [id :- ::s/id]
-          :return ::s/file-sharing
+          :return ::s/meta-sharing
           (let [[s r] (query/get-file-sharing-info (requester req) (:user req) id)]
             (if (success? s)
               (success s r)
@@ -225,12 +225,12 @@
                         operation :- ::s/sharing-operation]
           :return ::s/receipt-id-container
           (let [[s r headers] (activities/update-sharing!
-                                (activities req)
-                                (user req)
-                                id
-                                operation
-                                activity
-                                group-id)]
+                               (activities req)
+                               (user req)
+                               id
+                               operation
+                               activity
+                               group-id)]
             (if (success? s)
               (success ACCEPTED r headers)
               (fail s))))
@@ -240,10 +240,10 @@
           :path-params [id :- ::s/id]
           :return ::s/receipt-id-container
           (let [[s r headers] (activities/create-file-download!
-                                (activities req)
-                                (user req)
-                                (requester req)
-                                id)]
+                               (activities req)
+                               (user req)
+                               (requester req)
+                               id)]
             (if (success? s)
               (success ACCEPTED r headers)
               (fail s))))
@@ -254,12 +254,48 @@
                         link-id :- ::s/id]
           :return ::s/download-link-response
           (let [[s r headers] (activities/get-download-link-response
-                                (activities req)
-                                (user req)
-                                id
-                                link-id)]
+                               (activities req)
+                               (user req)
+                               id
+                               link-id)]
             (if (success? s)
               (success s r headers)
+              (fail s))))))
+
+    (context "/datapacks" []
+      (GET "/" req
+        :summary "Return a list of datapacks the user has access to"
+        :query-params [{count :- ::s/count nil}
+                       {index :- ::s/index nil}]
+        :return ::s/paged-datapacks
+        (let [[s r] (query/get-datapacks-by-user (requester req) (user req) {:count count :index index})]
+          (if (success? s)
+            (success s r)
+            (fail s))))
+
+      (context "/:id" []
+
+        (GET "/metadata" req
+          :summary "Return metadata for a specific datapack"
+          :path-params [id :- ::s/id]
+          :return ::s/datapack-metadata-get
+          (let [[s r] (query/get-datapack-metadata (requester req) (:user req) id)]
+            (if (success? s)
+              (success s r)
+              (fail s))))
+
+        (PUT "/metadata" req
+          :summary "Creates a new metadata for a datapack"
+          :path-params [id :- ::s/id]
+          :body [metadata ::s/datapack-metadata-put]
+          :return ::s/receipt-id-container
+          (let [[s r headers] (activities/create-datapack!
+                               (activities req)
+                               (user req)
+                               metadata
+                               id)]
+            (if (success? s)
+              (success ACCEPTED r headers)
               (fail s))))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/witan/httpapi/queries.clj
+++ b/src/witan/httpapi/queries.clj
@@ -19,6 +19,12 @@
   [{:keys [kixi.datastore.metadatastore/type]}]
   (= type "stored"))
 
+(defn datapack?
+  [{:keys [kixi.datastore.metadatastore/type
+           kixi.datastore.metadatastore/bundle-type]}]
+  (= type "bundle")
+  (= bundle-type "datapack"))
+
 (defn get-groups [requester user {:keys [count index]}]
   (let [[s r] (requests/GET requester
                             :heimdall
@@ -36,12 +42,12 @@
                                                   ::group/type]) (:items r)))
              (dissoc :items)))]))
 
-(defn get-files-by-user
-  [requester user {:keys [count index]}]
+(defn get-query-by-user
+  [query result-key requester user {:keys [count index]}]
   (let [[s r] (requests/POST requester
                              :search
                              "/metadata"
-                             {:form-params (merge {:query {:kixi.datastore.metadatastore.query/type {:equals "stored"}}}
+                             {:form-params (merge {:query query}
                                                   (when count
                                                     {:size count})
                                                   (when index
@@ -51,23 +57,47 @@
         {:keys [items]} r]
     (log/debug "Search /metadata returned:" s r)
     [s (-> r
-           (assoc :files items) ;;maintain pre-search api
+           (assoc result-key items) ;;maintain pre-search api
            (dissoc :items))]))
 
-(defn- get-file-info [requester user id]
+(def get-files-by-user
+  (partial get-query-by-user
+           {:kixi.datastore.metadatastore.query/type {:equals "stored"}}
+           :files))
+
+(defn- get-metadata-info [requester user id]
   (requests/GET requester
                 :datastore
                 (str "/metadata/" id)
                 {:headers (user-header user)}))
 
 (defn get-file-metadata [requester user id]
-  (let [[status cds-response] (get-file-info requester user id)]
+  (let [[status cds-response] (get-metadata-info requester user id)]
     (if (= status OK)
-      [status (dissoc cds-response :kixi.datastore.metadatastore/sharing)]
+      (if (file? cds-response)
+        [status (dissoc cds-response :kixi.datastore.metadatastore/sharing)]
+        [NOT_FOUND nil])
+      [status cds-response])))
+
+(defn get-datapack-metadata [requester user id]
+  (let [[status cds-response] (get-metadata-info requester user id)]
+    (if (= status OK)
+      (if (datapack? cds-response)
+        [status (dissoc cds-response :kixi.datastore.metadatastore/sharing)]
+        [NOT_FOUND nil])
       [status cds-response])))
 
 (defn get-file-sharing-info [requester user id]
-  (let [[status cds-response] (get-file-info requester user id)]
+  (let [[status cds-response] (get-metadata-info requester user id)]
     (if (= status OK)
-      [status (select-keys cds-response [:kixi.datastore.metadatastore/sharing])]
+      (if (file? cds-response)
+        [status (select-keys cds-response [:kixi.datastore.metadatastore/sharing])]
+        [NOT_FOUND nil])
       [status cds-response])))
+
+(def get-datapacks-by-user
+  (partial get-query-by-user
+           {:kixi.datastore.metadatastore.query/type {:equals "bundle"}
+            ;;:kixi.datastore.metadatastore.query/bundle-type {:equals "datapack"} ;; TODO we need to add this once we have more bundle types
+            }
+           :datapacks))

--- a/src/witan/httpapi/spec.clj
+++ b/src/witan/httpapi/spec.clj
@@ -20,6 +20,7 @@
             [kixi.user :as user]
             [kixi.group :as group]))
 
+(alias 'kd 'kixi.datastore)
 (alias 'kdmu-geography 'kixi.datastore.metadatastore.geography.update)
 (alias 'kdmu-license 'kixi.datastore.metadatastore.license.update)
 (alias 'kdmu-time 'kixi.datastore.metadatastore.time.update)
@@ -86,6 +87,7 @@
                 ::kdm/file-type
                 ::kdm/header
                 ::kdm/name]
+          ;; id is provided by path
           :opt [::kdm-time/temporal-coverage
                 ::kdm-geography/geography
                 ::kdm/source-created
@@ -95,16 +97,50 @@
                 ::kdm/author
                 ::kdm/source
                 ::kdm/maintainer
-                ::kdm/name
                 ::kdm/description
                 ::kdm/logo]))
 
-(s/def ::file-sharing
+(s/def ::datapack-metadata-get
+  (s/keys :req [::kdm/name
+                ::kdm/id
+                ::kdm/type
+                ::kdm/bundle-type
+                ::kdm/provenance]
+          :opt [::kdm/bundled-ids
+                ::kdm/description
+                ::kdm/logo
+                ::kdm/tags
+                ::kdm-license/license
+                ::kdm/author
+                ::kdm/maintainer
+                ::kdm/source
+                ::kdm/source-created
+                ::kdm/source-updated
+                ::kdm-time/temporal-coverage
+                ::kdm-geography/geography]))
+
+(s/def ::datapack-metadata-put
+  (s/keys :req [::kdm/name]
+          ;; id is provided by path
+          :opt [::kdm/bundled-ids
+                ::kdm-time/temporal-coverage
+                ::kdm-geography/geography
+                ::kdm/source-created
+                ::kdm/source-updated
+                ::kdm-license/license
+                ::kdm/tags
+                ::kdm/author
+                ::kdm/source
+                ::kdm/maintainer
+                ::kdm/description
+                ::kdm/logo]))
+
+(s/def ::meta-sharing
   (s/keys :req [::kdm/sharing]))
 
 (s/def ::file-info
   (s/merge ::file-metadata-get
-           ::file-sharing))
+           ::meta-sharing))
 
 (s/def ::metadata-update
   (s/merge (s/keys :req [::kdm/id])
@@ -119,6 +155,10 @@
                 ::kdm/sharing-update
                 ::group/id]))
 
+(s/def ::datapack-info
+  (s/merge ::datapack-metadata-get
+           ::meta-sharing))
+
 ;; Files
 (s/def ::total spec/int?)
 (s/def ::count spec/int?)
@@ -128,7 +168,9 @@
 (s/def ::paged-items (s/keys :req-un [::items ::paging]))
 
 (s/def ::files (s/coll-of ::file-info))
-(s/def ::paged-metadata-items (s/keys :req-un [::files ::paging]))
+(s/def ::datapacks (s/coll-of ::datapack-info))
+(s/def ::paged-files (s/keys :req-un [::files ::paging]))
+(s/def ::paged-datapacks (s/keys :req-un [::datapacks ::paging]))
 
 ;; Groups
 (s/def ::group-info (s/keys :req [::group/id ::group/name ::group/type]))
@@ -209,3 +251,8 @@
   [::kdm/sharing-change "1.0.0"]
   [_]
   ::sharing-command)
+
+(defmethod comms/command-payload
+  [::kd/create-datapack "1.0.0"]
+  [_]
+  ::datapack-info)

--- a/test/witan/httpapi/api_test.clj
+++ b/test/witan/httpapi/api_test.clj
@@ -67,6 +67,8 @@
 (def file-id (atom nil))
 (def file-metadata (atom nil))
 
+(def datapack-id (atom nil))
+
 (defn upload-new-file
   [all-tests]
   (let [auth (get-auth-tokens)
@@ -90,11 +92,43 @@
   (let [m (create-metadata file-name)
         new-metadata (send-file-and-metadata auth file-name m)]
     (when-not (and new-metadata (is-spec :witan.httpapi.spec/file-metadata-get new-metadata))
-      (throw (Exception. (str "Couldn't upload metadata: " new-metadata))))))
+      (throw (Exception. (str "Couldn't upload file metadata: " new-metadata))))))
+
+(defn create-datapack-inline
+  ([auth name]
+   (create-datapack-inline auth name (uuid)))
+  ([auth name id]
+   (log/info "Uploading a new datapack as part of the fixture.")
+   (if-let [success? (create-empty-datapack auth name id)]
+     (let [datapack (get-datapack auth id)]
+       (if-not (and datapack (is-spec :witan.httpapi.spec/datapack-metadata-get datapack))
+         (throw (Exception. (str "Datapack was invalid " (spec/explain-data :witan.httpapi.spec/datapack-metadata-get datapack))))
+         datapack))
+     (throw (Exception. (str "Couldn't upload datapack metadata"))))))
+
+(defn create-new-datapack
+  [all-tests]
+  (let [id (uuid)
+        auth (get-auth-tokens)
+        name (str "fixture-datapack-" (rand-int Integer/MAX_VALUE))
+        datapack (create-datapack-inline auth name id)]
+    (if-let [err (cond
+                   (not datapack) "returned nil"
+                   (not= id (::ms/id datapack)) "id didn't match"
+                   (not= name (::ms/name datapack)) "name didn't match"
+                   :else nil)]
+      (throw (Exception. (str "Couldn't create datapack - " err)))
+      (do
+        (reset! datapack-id (::ms/id datapack))
+        (all-tests)
+        (reset! datapack-id nil)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(use-fixtures :once start-system upload-new-file)
+(use-fixtures :once
+  start-system
+  upload-new-file
+  create-new-datapack)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -173,6 +207,29 @@
             {:keys [total count index]} (get-paging r)]
         (is (= 1 index))))))
 
+(deftest get-datapacks-paging-test
+  (let [auth (get-auth-tokens)
+        r @(http/get (url "/api/datapacks")
+                     (with-default-opts
+                       {:headers {:authorization (:auth-token auth)}}))]
+    (when (= 1 (:total (get-paging r)))
+      ;; upload a new metadata - so we know there's more than 1
+      (create-datapack-inline auth (str "get-datapacks-paging-test-" (rand-int Integer/MAX_VALUE))))
+
+    (testing "Is the number of results being limited?"
+      (let [r @(http/get (url "/api/datapacks?count=1")
+                         (with-default-opts
+                           {:headers {:authorization (:auth-token auth)}}))
+            {:keys [total count index]} (get-paging r)]
+        (is (= 1 count))))
+
+    (testing "Is the index being increased?"
+      (let [r @(http/get (url "/api/datapacks?index=1")
+                         (with-default-opts
+                           {:headers {:authorization (:auth-token auth)}}))
+            {:keys [total count index]} (get-paging r)]
+        (is (= 1 index))))))
+
 (deftest get-groups-paging-test
   (let [auth (get-auth-tokens)]
     (testing "Is the number of results being limited?"
@@ -204,7 +261,7 @@
                      (with-default-opts
                        {:headers {:authorization (:auth-token auth)}}))]
     (when-success r
-      (is-spec :witan.httpapi.spec/file-sharing (:body (coerce-response r))))))
+      (is-spec :witan.httpapi.spec/meta-sharing (:body (coerce-response r))))))
 
 (deftest update-metadata-test
   (let [auth (get-auth-tokens)

--- a/test/witan/httpapi/api_test.clj
+++ b/test/witan/httpapi/api_test.clj
@@ -174,7 +174,15 @@
                      (with-default-opts
                        {:headers {:authorization (:auth-token auth)}}))]
     (when-success r
-      (is-spec :witan.httpapi.spec/paged-metadata-items (:body (coerce-response r))))))
+      (is-spec :witan.httpapi.spec/paged-files (:body (coerce-response r))))))
+
+(deftest get-datapacks-test
+  (let [auth (get-auth-tokens)
+        r @(http/get (url "/api/datapacks")
+                     (with-default-opts
+                       {:headers {:authorization (:auth-token auth)}}))]
+    (when-success r
+      (is-spec :witan.httpapi.spec/paged-datapacks (:body (coerce-response r))))))
 
 (deftest get-groups-test
   (let [auth (get-auth-tokens)

--- a/test/witan/httpapi/api_test.clj
+++ b/test/witan/httpapi/api_test.clj
@@ -100,7 +100,7 @@
   ([auth name id]
    (log/info "Uploading a new datapack as part of the fixture.")
    (if-let [success? (create-empty-datapack auth name id)]
-     (let [datapack (get-datapack auth id)]
+     (let [datapack (wait-for-pred #(get-datapack auth id))]
        (if-not (and datapack (is-spec :witan.httpapi.spec/datapack-metadata-get datapack))
          (throw (Exception. (str "Datapack was invalid " (spec/explain-data :witan.httpapi.spec/datapack-metadata-get datapack))))
          datapack))

--- a/test/witan/httpapi/spec_test.clj
+++ b/test/witan/httpapi/spec_test.clj
@@ -12,7 +12,7 @@
                                     (swap! results conj %)) %) schema)
       (is (empty? @results))))
   (testing "paged-metadata-items"
-    (let [schema (swagger/transform ::s/paged-metadata-items)
+    (let [schema (swagger/transform ::s/paged-files)
           results (atom [])]
       (clojure.walk/postwalk #(do (when (= [] (:required %))
                                     (swap! results conj %)) %) schema)

--- a/test/witan/httpapi/test_base.clj
+++ b/test/witan/httpapi/test_base.clj
@@ -59,6 +59,21 @@
          url)
     (throw (Exception. "Not a map!"))))
 
+(defn wait-for-pred
+  ([p]
+   (wait-for-pred p wait-tries))
+  ([p tries]
+   (wait-for-pred p tries wait-per-try))
+  ([p tries ms]
+   (loop [try tries]
+     (when (and (pos? try))
+       (let [result (p)]
+         (if (not result)
+           (do
+             (Thread/sleep ms)
+             (recur (dec try)))
+           result))))))
+
 (defn wait-for-receipt
   ([auth receipt-resp]
    (wait-for-receipt auth (receipt-resp->receipt-url receipt-resp) wait-tries 1 nil))

--- a/test/witan/httpapi/test_base.clj
+++ b/test/witan/httpapi/test_base.clj
@@ -256,3 +256,29 @@
                   (is-submap metadata (:body (api/coerce-response receipt-resp)))
                   (:body (api/coerce-response receipt-resp)))
                 (println "Error was returned:" (-> receipt-resp :body :error) "\nIf error is `file-not-exist` it could be because the tests are running elsewhere.")))))))))
+
+(defn create-empty-datapack
+  [auth name id]
+  (let [metadata {::ms/id id
+                  ::ms/name name}
+        resp @(http/put (url (str "/api/datapacks/" id "/metadata"))
+                        {:throw-exceptions false
+                         :content-type :json
+                         :as :json
+                         :headers {:authorization (:auth-token auth)}
+                         :form-params metadata})]
+    (when-accepted resp
+      (let [receipt-resp (wait-for-receipt auth resp)]
+        (is (= 200 (:status receipt-resp))
+            "metadata receipt")
+        (= 200 (:status receipt-resp))))))
+
+(defn get-datapack
+  [auth id]
+  (let [resp @(http/get (url (str "/api/datapacks/" id "/metadata"))
+                        {:throw-exceptions false
+                         :content-type :json
+                         :as :json
+                         :headers {:authorization (:auth-token auth)}})]
+    (when-success resp
+      (:body (api/coerce-response resp)))))


### PR DESCRIPTION
This is the first of a concerted effort to complete the datapack portion of the API. In this PR we add the ability to:
- Create datapacks (PUT /api/datapacks/\<id\>/metadata)
- Get a list of your datapacks (GET /api/datapacks)
- Retrieve a specific datapack (GET /api/datapacks/\<id\>/metadata)

So far we have not covered updating datapack metadata, nor adding/removing files from a datapack. Those will be in a subsequent PR.