### PR TITLE
Add routes and tests for updating sharing details of datapacks

### DIFF
--- a/src/witan/httpapi/api.clj
+++ b/src/witan/httpapi/api.clj
@@ -324,6 +324,34 @@
                                file-id)]
             (if (success? s)
               (success ACCEPTED r headers)
+              (fail s))))
+
+        (GET "/sharing" req
+             :summary "Return sharing data for a specific datapack"
+          :path-params [id :- ::s/id]
+          :return ::s/meta-sharing
+          (let [[s r] (query/get-datapack-sharing-info (requester req) (:user req) id)]
+            (if (success? s)
+              (success s r)
+              (fail s))))
+
+        (POST "/sharing" req
+          :summary "Add a group to the specified datapack with a particular permission"
+          :path-params [id :- ::s/id]
+          :body-params [activity :- ::kdm/activity
+                        group-id :- ::group/id
+                        operation :- ::s/sharing-operation]
+          :return ::s/receipt-id-container
+          ;; HACK; we don't actually check whether this is a datapack
+          (let [[s r headers] (activities/update-sharing!
+                               (activities req)
+                               (user req)
+                               id
+                               operation
+                               activity
+                               group-id)]
+            (if (success? s)
+              (success ACCEPTED r headers)
               (fail s))))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/witan/httpapi/api.clj
+++ b/src/witan/httpapi/api.clj
@@ -298,7 +298,7 @@
               (success ACCEPTED r headers)
               (fail s))))
 
-        (PUT "/files/:file-id" req
+        (POST "/files/:file-id" req
           :summary "Adds a file to a datapack"
           :path-params [id :- ::s/id
                         file-id :- ::s/id]

--- a/src/witan/httpapi/queries.clj
+++ b/src/witan/httpapi/queries.clj
@@ -95,6 +95,14 @@
         [NOT_FOUND nil])
       [status cds-response])))
 
+(defn get-datapack-sharing-info [requester user id]
+  (let [[status cds-response] (get-metadata-info requester user id)]
+    (if (= status OK)
+      (if (datapack? cds-response)
+        [status (select-keys cds-response [:kixi.datastore.metadatastore/sharing])]
+        [NOT_FOUND nil])
+      [status cds-response])))
+
 (def get-datapacks-by-user
   (partial get-query-by-user
            {:kixi.datastore.metadatastore.query/type {:equals "bundle"}

--- a/test/witan/httpapi/api_test.clj
+++ b/test/witan/httpapi/api_test.clj
@@ -436,9 +436,9 @@
 (deftest add-remove-files-datapack-test
   (let [auth (get-auth-tokens)]
     (testing "adding a file"
-      (let [r @(http/put (url (str "/api/datapacks/" @datapack-id "/files/" @file-id))
-                         (with-default-opts
-                           {:headers {:authorization (:auth-token auth)}}))]
+      (let [r @(http/post (url (str "/api/datapacks/" @datapack-id "/files/" @file-id))
+                          (with-default-opts
+                            {:headers {:authorization (:auth-token auth)}}))]
         (when-accepted r
           (let [receipt-resp (wait-for-receipt auth r)]
             (when-success receipt-resp
@@ -474,17 +474,17 @@
   (let [auth (get-auth-tokens)
         id (uuid)]
     (testing "adding to a missing datapack"
-      (let [r @(http/put (url (str "/api/datapacks/" id "/files/" @file-id))
-                         (with-default-opts
-                           {:headers {:authorization (:auth-token auth)}}))]
+      (let [r @(http/post (url (str "/api/datapacks/" id "/files/" @file-id))
+                          (with-default-opts
+                            {:headers {:authorization (:auth-token auth)}}))]
         (when-accepted r
           (let [receipt-resp (wait-for-receipt auth r)]
             (when-success receipt-resp
               (is (= "incorrect-type" (get-in receipt-resp [:body :error :witan.httpapi.spec/reason])))))))) ;; why incorrect-type???
     (testing "adding to a file.. ?"
-      (let [r @(http/put (url (str "/api/datapacks/" @file-id "/files/" @file-id))
-                         (with-default-opts
-                           {:headers {:authorization (:auth-token auth)}}))]
+      (let [r @(http/post (url (str "/api/datapacks/" @file-id "/files/" @file-id))
+                          (with-default-opts
+                            {:headers {:authorization (:auth-token auth)}}))]
         (when-accepted r
           (let [receipt-resp (wait-for-receipt auth r)]
             (when-success receipt-resp

--- a/test/witan/httpapi/api_test.clj
+++ b/test/witan/httpapi/api_test.clj
@@ -264,12 +264,19 @@
       (is-spec :witan.httpapi.spec/file-metadata-get (:body (coerce-response r))))))
 
 (deftest get-metadata-sharing-test
-  (let [auth (get-auth-tokens)
-        r @(http/get (url (str "/api/files/" @file-id "/sharing"))
-                     (with-default-opts
-                       {:headers {:authorization (:auth-token auth)}}))]
-    (when-success r
-      (is-spec :witan.httpapi.spec/meta-sharing (:body (coerce-response r))))))
+  (let [auth (get-auth-tokens)]
+    (testing "files"
+      (let [r @(http/get (url (str "/api/files/" @file-id "/sharing"))
+                         (with-default-opts
+                           {:headers {:authorization (:auth-token auth)}}))]
+        (when-success r
+          (is-spec :witan.httpapi.spec/meta-sharing (:body (coerce-response r))))))
+    (testing "datapacks"
+      (let [r @(http/get (url (str "/api/datapacks/" @datapack-id "/sharing"))
+                         (with-default-opts
+                           {:headers {:authorization (:auth-token auth)}}))]
+        (when-success r
+          (is-spec :witan.httpapi.spec/meta-sharing (:body (coerce-response r))))))))
 
 (deftest update-metadata-test
   (let [auth (get-auth-tokens)
@@ -372,11 +379,12 @@
             (when-success receipt-resp
               (is-spec ::s/download-link-response (:body (coerce-response receipt-resp))))))))))
 
-(deftest sharing-update-test
+(defn metadata-sharing-update-test
+  [url-prefix md-id]
   (let [auth (get-auth-tokens)
         new-grp (uuid)]
     (testing "Adding a new group to the sharing properties of our file"
-      (let [r @(http/post (url (str "/api/files/" @file-id "/sharing"))
+      (let [r @(http/post (url (str url-prefix md-id "/sharing"))
                           (with-default-opts
                             {:form-params {:activity ::ms/file-read
                                            :operation "add"
@@ -386,13 +394,13 @@
           (let [receipt-resp (wait-for-receipt auth r)]
             (when-success receipt-resp
               (Thread/sleep 4000) ;; eventual consistency, innit
-              (let [sharing-r @(http/get (url (str "/api/files/" @file-id "/sharing"))
+              (let [sharing-r @(http/get (url (str url-prefix md-id "/sharing"))
                                          (with-default-opts
                                            {:headers {:authorization (:auth-token auth)}}))]
                 (is (contains? (set (get-in sharing-r [:body ::ms/sharing ::ms/file-read])) new-grp))))))))
 
     (testing "Removing a group from the sharing properties of our file"
-      (let [r @(http/post (url (str "/api/files/" @file-id "/sharing"))
+      (let [r @(http/post (url (str url-prefix md-id "/sharing"))
                           (with-default-opts
                             {:form-params {:activity ::ms/file-read
                                            :operation "remove"
@@ -402,13 +410,13 @@
           (Thread/sleep 4000) ;; eventual consistency, innit
           (let [receipt-resp (wait-for-receipt auth r)]
             (when-success receipt-resp
-              (let [sharing-r @(http/get (url (str "/api/files/" @file-id "/sharing"))
+              (let [sharing-r @(http/get (url (str url-prefix md-id "/sharing"))
                                          (with-default-opts
                                            {:headers {:authorization (:auth-token auth)}}))]
                 (is (not (contains? (set (get-in sharing-r [:body ::ms/sharing ::ms/file-read])) new-grp)))))))))
 
     (testing "Adding a new group to the sharing properties of a file that DOESN'T exist"
-      (let [r @(http/post (url (str "/api/files/" (uuid) "/sharing"))
+      (let [r @(http/post (url (str url-prefix (uuid) "/sharing"))
                           (with-default-opts
                             {:form-params {:activity ::ms/file-read
                                            :operation "add"
@@ -418,6 +426,12 @@
           (let [receipt-resp (wait-for-receipt auth r)]
             (when-success receipt-resp
               (is (= "unauthorised" (get-in receipt-resp [:body :error :witan.httpapi.spec/reason]))))))))))
+
+(deftest files-sharing-update-test
+  (metadata-sharing-update-test "/api/files/" @file-id))
+
+(deftest datapack-sharing-update-test
+  (metadata-sharing-update-test "/api/datapacks/" @datapack-id))
 
 (deftest add-remove-files-datapack-test
   (let [auth (get-auth-tokens)]


### PR DESCRIPTION
Following on from previous datapack changes, you can now query the sharing metadata of a datapack, and update it:

 - GET /api/datapacks/\<id\>/sharing
 - POST /api/datapacks/\<id\>/sharing
 
 There is a known issue; the POST doesn't discern whether or not the passed in ID is actually a datapack.